### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -24,6 +24,6 @@
       "!{projectRoot}/test/**/*"
     ]
   },
-  "nxCloudAccessToken": "NDk4MmNkMDAtYjI4ZS00YjlmLTlkNjItMzAxZjAxYTcwZmE2fHJlYWQtd3JpdGU=",
-  "nxCloudUrl": "https://staging.nx.app"
+  "nxCloudAccessToken": "MDMwYmE4NDMtYjRhYi00ZjgyLThiMjQtYjJiNDRlNTIyYzI3fHJlYWQtd3JpdGU=",
+  "nxCloudUrl": "http://localhost:4202"
 }

--- a/nx.json
+++ b/nx.json
@@ -24,6 +24,6 @@
       "!{projectRoot}/test/**/*"
     ]
   },
-  "nxCloudAccessToken": "MDMwYmE4NDMtYjRhYi00ZjgyLThiMjQtYjJiNDRlNTIyYzI3fHJlYWQtd3JpdGU=",
+  "nxCloudAccessToken": "MmI4ZGY2YWMtOTA5Ni00NDMxLThkZTItZWViYTU3YTkxYTkyfHJlYWQtd3JpdGU=",
   "nxCloudUrl": "http://localhost:4202"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
http://localhost:4202/orgs/660d673995c1b45c1739e4b4/workspaces/6638e7e734a70435b84fbd07

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.